### PR TITLE
[Refactor] 마이페이지, 계정 설정 페이지, 검색 페이지 레이아웃

### DIFF
--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -3,8 +3,8 @@ import { cva } from 'class-variance-authority';
 import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  width: string;
-  height: string;
+  width?: string;
+  height?: string;
   variants?: 'filled' | 'outline' | 'text';
   radius: 'sm' | 'md' | 'lg' | 'full';
   className?: string;

--- a/src/components/molecules/ContributionBox.tsx
+++ b/src/components/molecules/ContributionBox.tsx
@@ -10,9 +10,13 @@ const ContributionBox = ({ text, amount, onClick }: ContributionBoxProps) => {
       className='max-w-[260px] h-[80px] rounded-[5px] bg-white flex flex-col justify-between p-[10px]'
       onClick={onClick}
     >
-      <span className='text-darkgray font-medium text-[15px]'>{text}</span>
+      <span className='text-darkgray font-medium text-[15px] text-left'>
+        {text}
+      </span>
       <p className='w-full flex justify-end'>
-        <span className='text-[30px] font-semibold text-black'>{amount}</span>
+        <span className='text-[30px] font-semibold text-black'>
+          {amount || 0}
+        </span>
       </p>
     </button>
   );

--- a/src/components/molecules/chat/MessageButton.tsx
+++ b/src/components/molecules/chat/MessageButton.tsx
@@ -14,14 +14,13 @@ const MessageButton = ({ targetUserId }: MessageButtonProps) => {
 
   return (
     <Button
-      width='92px'
-      height='29px'
       radius='sm'
       variants='outline'
-      className='font-semibold text-[15px] flex items-center justify-center gap-[10px] border border-black'
+      className='font-semibold text-[15px] flex items-center justify-center gap-[10px] border border-black !px-3 !py-1'
       onClick={clickMessageButton}
     >
-      메세지 <EnvelopeIcon width={18} />
+      <span className='hidden sm:block'>메세지</span>{' '}
+      <EnvelopeIcon width={18} />
     </Button>
   );
 };

--- a/src/components/molecules/contents/FeedContentsUserTitle.tsx
+++ b/src/components/molecules/contents/FeedContentsUserTitle.tsx
@@ -4,11 +4,13 @@ interface FeedContentsUserTitleProps {
   userNickname: string;
   userRole: string;
   createdAt: string;
+  hideRole?: boolean;
 }
 const FeedContentsUserTitle = ({
   userNickname,
   userRole,
   createdAt,
+  hideRole,
 }: FeedContentsUserTitleProps) => {
   return (
     <div className='flex items-start gap-3'>
@@ -17,15 +19,17 @@ const FeedContentsUserTitle = ({
           {userNickname}
         </span>
       </div>
-      <div className='flex items-center gap-[2px]'>
-        <span className='text-slate-600 text-sm'>{userRole}</span>
-        <span className='text-slate-700 bg-gray-200 rounded-full text-sm'>
-          •
-        </span>
-        <span className='text-slate-700 text-sm'>
-          {formatTimeAgo(createdAt)}
-        </span>
-      </div>
+      {!hideRole && (
+        <div className='flex items-center gap-[2px]'>
+          <span className='text-slate-600 text-sm'>{userRole}</span>
+          <span className='text-slate-700 bg-gray-200 rounded-full text-sm'>
+            •
+          </span>
+          <span className='text-slate-700 text-sm'>
+            {formatTimeAgo(createdAt)}
+          </span>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/molecules/feed/ContentsUser.tsx
+++ b/src/components/molecules/feed/ContentsUser.tsx
@@ -7,6 +7,7 @@ interface ContentsUserProps {
   name: string;
   userRole: string;
   userId?: number;
+  hideRole?: boolean;
 }
 
 const ContentsUser = ({
@@ -15,6 +16,7 @@ const ContentsUser = ({
   userRole,
   userProfileUrl,
   userId,
+  hideRole,
 }: ContentsUserProps) => {
   return (
     <div className='flex items-center sm:mb-1 px-0 sm:px-0 gap-2'>
@@ -29,6 +31,7 @@ const ContentsUser = ({
         userNickname={name}
         userRole={userRole}
         createdAt={createdAt}
+        hideRole={hideRole}
       />
     </div>
   );

--- a/src/components/organisms/ConnectionHubDetail.tsx
+++ b/src/components/organisms/ConnectionHubDetail.tsx
@@ -1,9 +1,10 @@
 import { useFetchHub } from '@/hooks/queries/hub.query';
 import useAuthStore from '@/store/authStore';
 import { useProjectStore } from '@/store/hubDetailStore';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { useEffect } from 'react';
 import HubDetail from '@/components/organisms/hub/HubDetail';
+import { useSearchModal } from '@/store/modals/searchModalstore';
 
 const ConnectionHubDetail = () => {
   const { projectId } = useParams<{ projectId: string }>();
@@ -12,6 +13,26 @@ const ConnectionHubDetail = () => {
     isLoading: ProjectLoading,
     isError,
   } = useFetchHub(Number(projectId));
+
+  // 검색 관련 코드
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+  const { keyword: searchKeyword } = useSearchModal();
+
+  useEffect(() => {
+    if (query.get('from') === 'search') {
+      const handlePopState = () => {
+        const currentUrl = window.location.href;
+        const newUrl = currentUrl.includes('q=')
+          ? currentUrl
+          : `${currentUrl}?q=${searchKeyword}`;
+        window.history.pushState(null, '', newUrl);
+      };
+
+      window.addEventListener('popstate', handlePopState);
+      return () => window.removeEventListener('popstate', handlePopState);
+    }
+  }, [location]);
 
   const setProject = useProjectStore((state) => state.setProject);
   const isOwnConnectionHub = useProjectStore(

--- a/src/components/organisms/feed/FeedListContent.tsx
+++ b/src/components/organisms/feed/FeedListContent.tsx
@@ -20,6 +20,7 @@ interface FeedContentsProps {
     name: string;
     job: string;
     time: string;
+    hideRole?: boolean;
   };
 }
 
@@ -47,6 +48,7 @@ const FeedListContent = ({
               userRole={user.job}
               createdAt={createdAt}
               userId={user.id!}
+              hideRole={user.hideRole}
             />
             <FeedItem
               title={title}

--- a/src/components/organisms/modals/SearchModal.tsx
+++ b/src/components/organisms/modals/SearchModal.tsx
@@ -101,7 +101,7 @@ const SearchModal = ({ onClose }: ModalProps) => {
                   hasMore={data?.feedResult?.hasMore as boolean}
                   hasMoreNavigate={() => {
                     setActiveTab('피드');
-                    navigate(`/search?q=${debouncedKeyword}`);
+                    navigate(`/search?q=${debouncedKeyword}&type=page`);
                     onClose();
                   }}
                 />

--- a/src/components/organisms/modals/SearchModal.tsx
+++ b/src/components/organisms/modals/SearchModal.tsx
@@ -45,6 +45,8 @@ const SearchModal = ({ onClose }: ModalProps) => {
   const hubs = data?.projectResult?.projects;
 
   const closeHandler = () => {
+    const currentPath = window.location.pathname;
+    navigate(currentPath);
     onClose();
     setKeyword('');
   };

--- a/src/components/organisms/mypage/Contribution.tsx
+++ b/src/components/organisms/mypage/Contribution.tsx
@@ -14,7 +14,7 @@ const Contribution = ({ clickHandler }: IProps) => {
   const { profileInfo } = useIntroduction();
 
   return (
-    <div className='flex-1 h-full rounded-[20px] bg-lightgray py-[10px] px-[10px]'>
+    <div className='flex-1 sm:h-full rounded-[20px] bg-[#eeeeee] py-[10px] px-[10px]'>
       <span className='text-[15px] font-medium text-darkgray'>
         PAD Contribution
       </span>

--- a/src/components/organisms/search/FeedView.tsx
+++ b/src/components/organisms/search/FeedView.tsx
@@ -46,6 +46,7 @@ const FeedView = ({ keyword }: { keyword: string }) => {
             name: post.userNickname,
             job: post.userRole,
             time: post.createdAt,
+            hideRole: true,
           }}
         />
       ))}

--- a/src/components/organisms/settings/SettingsSection.tsx
+++ b/src/components/organisms/settings/SettingsSection.tsx
@@ -108,7 +108,7 @@ SettingsSection.TextWithToggle = function ({
 }) {
   return (
     <div className='flex justify-between items-center'>
-      <div className='flex flex-col gap-1 text-[15px]'>
+      <div className='flex flex-col gap-1 text-[15px] mr-[10px] sm:mr-0'>
         <strong className='text-black font-medium'>{title}</strong>
         <span className='text-[#7D7D7D]'>{description}</span>
       </div>

--- a/src/components/organisms/sides/MobileNav.tsx
+++ b/src/components/organisms/sides/MobileNav.tsx
@@ -26,9 +26,9 @@ const MobileNav = () => {
           className='flex flex-row items-center mr-1 w-full'
         >
           <a href='/' className='w-[40px] h-[16px]'>
-            <Logo width='40px' height='16px' />
+            <Logo width='44px' height='18px' />
           </a>
-          <div className='w-full h-8 pl-3 pr-1 py-[6px] border rounded-lg border-none bg-lightgray flex ml-2 mr-1'>
+          <div className='w-full h-8 pl-3 pr-1 py-[6px] border rounded-lg border-none bg-lightgray flex ml-6 mr-1'>
             <div className='w-5 h-5'>
               <Icon type='search' className='text-gray' />
             </div>

--- a/src/components/organisms/sides/MobileNav.tsx
+++ b/src/components/organisms/sides/MobileNav.tsx
@@ -14,7 +14,7 @@ const MobileNav = () => {
 
   const keyHandler = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
-      navigate(`/search?q=${keyword}`);
+      navigate(`/search?q=${keyword}&type=page`);
     }
   };
 

--- a/src/components/organisms/sides/MobileNav.tsx
+++ b/src/components/organisms/sides/MobileNav.tsx
@@ -1,28 +1,46 @@
 import Icon from '@/components/atoms/Icon';
+import Input from '@/components/atoms/Input';
 import Logo from '@/components/atoms/Logo';
+import { useSearchModal } from '@/store/modals/searchModalstore';
+import { KeyboardEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useShallow } from 'zustand/shallow';
 
 const MobileNav = () => {
+  const navigate = useNavigate();
+  const [keyword, setKeyword] = useSearchModal(
+    useShallow((state) => [state.keyword, state.setKeyword])
+  );
+
+  const keyHandler = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      navigate(`/search?q=${keyword}`);
+    }
+  };
+
   return (
     <div className='border-b border-lightgray w-full h-full'>
       <div className='w-full h-full flex items-center px-2 justify-between'>
         <nav
-          aria-aria-label='모바일 메뉴'
+          aria-label='모바일 메뉴'
           className='flex flex-row items-center mr-1 w-full'
         >
           <a href='/' className='w-[40px] h-[16px]'>
             <Logo width='40px' height='16px' />
           </a>
-          <a href='/search' className='w-full h-full ml-3'>
-            <div className='w-full h-8 px-3 py-[6px] border rounded-lg border-none bg-lightgray flex'>
-              <div className='w-5 h-5'>
-                <Icon type={'search'} className='text-gray' />
-              </div>
-              <input
-                className='w-full bg-transparent text-lg'
-                placeholder='검색하기'
-              />
+          <div className='w-full h-8 pl-3 pr-1 py-[6px] border rounded-lg border-none bg-lightgray flex ml-2 mr-1'>
+            <div className='w-5 h-5'>
+              <Icon type='search' className='text-gray' />
             </div>
-          </a>
+            <Input
+              placeholder='검색어 입력'
+              bgColor='transparent'
+              className='border-0 !text-[16px] spacing-none ml-[-10px]'
+              value={keyword}
+              onChange={(e) => setKeyword(e.target.value)}
+              onKeyDown={keyHandler}
+            />
+          </div>
         </nav>
         <nav className='flex w-[102px] h-8 bg-blue-300'></nav>
       </div>

--- a/src/components/organisms/sides/MobileNav.tsx
+++ b/src/components/organisms/sides/MobileNav.tsx
@@ -35,7 +35,7 @@ const MobileNav = () => {
             <Input
               placeholder='검색어 입력'
               bgColor='transparent'
-              className='border-0 !text-[16px] spacing-none ml-[-10px]'
+              className='border-0 !text-sm spacing-none ml-[-10px]'
               value={keyword}
               onChange={(e) => setKeyword(e.target.value)}
               onKeyDown={keyHandler}

--- a/src/components/organisms/sides/SideMenu.tsx
+++ b/src/components/organisms/sides/SideMenu.tsx
@@ -180,7 +180,7 @@ const SideMenu = () => {
     <>
       {isSearchModalOpen && <SearchModal onClose={closeSearchModal} />}
 
-      <div className='flex lg:flex-col lg:py-[20px] justify-between items-center h-full bg-green-200'>
+      <div className='flex lg:flex-col lg:py-[20px] justify-between items-center h-full'>
         <div className='mb-8 cursor-pointer' onClick={() => navigate('/')}>
           <Logo />
         </div>

--- a/src/components/pages/FeedDetailPage.tsx
+++ b/src/components/pages/FeedDetailPage.tsx
@@ -4,8 +4,9 @@ import FeedDetailSkeleton from '@/components/molecules/skeletons/FeedDetailSkele
 import FeedDetail from '@/components/organisms/feed/FeedDetail';
 import { useFetchFeed, useFetchFeedChat } from '@/hooks/queries/feed.query';
 import useAuthStore from '@/store/authStore';
-import { Suspense, lazy } from 'react';
-import { useParams } from 'react-router-dom';
+import { useSearchModal } from '@/store/modals/searchModalstore';
+import { Suspense, lazy, useEffect } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
 
 const FeedDetailChat = lazy(() => {
   return import('@/components/organisms/feed/FeedDetailChat');
@@ -18,15 +19,30 @@ const FeedDetailPage = () => {
     Number(id)
   );
 
+  // 검색 관련 코드
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+  const { keyword: searchKeyword } = useSearchModal();
+
+  useEffect(() => {
+    if (query.get('from') === 'search') {
+      const handlePopState = () => {
+        const currentUrl = window.location.href;
+        const newUrl = currentUrl.includes('q=')
+          ? currentUrl
+          : `${currentUrl}?q=${searchKeyword}`;
+        window.history.pushState(null, '', newUrl);
+      };
+
+      window.addEventListener('popstate', handlePopState);
+      return () => window.removeEventListener('popstate', handlePopState);
+    }
+  }, [location]);
+
   const post = FeedData?.post;
   const comments = ChatData?.comments;
 
   const userId = useAuthStore((state) => state.userInfo?.userId);
-
-  // NOTE: 검색 모달 관련 코드
-  // const { isModalOpen, openModal, closeModal, keyword, setKeyword } =
-  //   useSearchModal(useShallow((state) => state));
-  // useHandlePopState(keyword, openModal, setKeyword);
 
   if (FeedLoading) {
     return <div>피드 로딩중</div>;

--- a/src/components/pages/SearchPage.tsx
+++ b/src/components/pages/SearchPage.tsx
@@ -1,6 +1,8 @@
 import FeedView from '@/components/organisms/search/FeedView';
 import ProjectView from '@/components/organisms/search/ProjectView';
+import { useSearchModal } from '@/store/modals/searchModalstore';
 import { useSearchTabsStore } from '@/store/searchTabsStore';
+import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useShallow } from 'zustand/shallow';
 
@@ -8,6 +10,23 @@ const SearchPage = () => {
   const { search } = useLocation();
   const query = new URLSearchParams(search);
   const keyword = query.get('q') as string;
+
+  const { keyword: searchKeyword } = useSearchModal();
+
+  useEffect(() => {
+    if (query.get('q')) {
+      const handlePopState = () => {
+        const currentUrl = window.location.href;
+        const newUrl = currentUrl.includes('q=')
+          ? currentUrl
+          : `${currentUrl}?q=${searchKeyword}`;
+        window.history.pushState(null, '', newUrl);
+      };
+
+      window.addEventListener('popstate', handlePopState);
+      return () => window.removeEventListener('popstate', handlePopState);
+    }
+  }, [location]);
 
   const { tabs, activeTab, setActiveTab } = useSearchTabsStore(
     useShallow((state) => state)

--- a/src/components/pages/SearchPage.tsx
+++ b/src/components/pages/SearchPage.tsx
@@ -20,7 +20,11 @@ const SearchPage = () => {
         const newUrl = currentUrl.includes('q=')
           ? currentUrl
           : `${currentUrl}?q=${searchKeyword}`;
-        window.history.pushState(null, '', newUrl);
+        window.history.pushState(
+          null,
+          '',
+          window.innerWidth >= 768 ? newUrl : currentUrl // 탭 이하는 모달 제외
+        );
       };
 
       window.addEventListener('popstate', handlePopState);

--- a/src/components/pages/SearchPage.tsx
+++ b/src/components/pages/SearchPage.tsx
@@ -16,7 +16,7 @@ const SearchPage = () => {
   if (!keyword) return null;
 
   return (
-    <div className='flex flex-col gap-5'>
+    <div className='flex flex-col gap-5 px-5 md:px-0'>
       <h1 className='flex gap-4 items-center text-[25px] font-semibold'>
         <span className='text-[#FFBA6C]'>&ldquo;{keyword}&rdquo;</span>
         <span>검색 결과</span>

--- a/src/components/templates/MyPage/ApplyTemplate.tsx
+++ b/src/components/templates/MyPage/ApplyTemplate.tsx
@@ -41,9 +41,7 @@ const ApplyTemplate = () => {
   return (
     <div className='flex flex-col gap-[17px]'>
       {!originResume && !isMyPage && (
-        <div className='flex w-full h-10 justify-center items-center'>
-          지원서가 존재하지 않습니다.
-        </div>
+        <div className='flex justify-center mt-3'>지원서가 않습니다.</div>
       )}
       {isEditing && isMyPage && (
         <form

--- a/src/components/templates/MyPage/ConnectionHubTemplate.tsx
+++ b/src/components/templates/MyPage/ConnectionHubTemplate.tsx
@@ -42,6 +42,9 @@ const ConnectionHubTemplate = () => {
           </button>
         ))}
       </div>
+      {!isLoading && !data && (
+        <div className='flex justify-center mt-3'>허브가 않습니다.</div>
+      )}
       {data?.pages[0].projects.length === 0 && (
         <div className='flex justify-center text-[13px]'>
           프로젝트가 존재하지 않습니다.

--- a/src/components/templates/MyPage/FeedTemplate.tsx
+++ b/src/components/templates/MyPage/FeedTemplate.tsx
@@ -28,6 +28,9 @@ const FeedTemplate = () => {
           {error && <span className='text-red-500'>에러가 발생했습니다.</span>}
         </div>
       )}
+      {!isLoading && data === undefined && (
+        <div className='flex justify-center'>피드가 않습니다.</div>
+      )}
       {data?.pages.map((page: FeedResponse) => {
         let lastDate = '';
         return page.feeds.map((feed) => {

--- a/src/components/templates/MyPage/IntroductionTemplate.tsx
+++ b/src/components/templates/MyPage/IntroductionTemplate.tsx
@@ -55,18 +55,20 @@ const IntroductionTemplate = () => {
         onClose={followersModal.close}
         type={followersModal.isOpen!}
       />
-      <div className='h-[250px] py-[10px] flex items-center gap-[17px]'>
-        <div className='flex flex-col gap-[10px] bg-status w-[230px] h-[230px] rounded-[20px] py-4 px-4 relative'>
+      <div className='h-[250px] sm:py-[10px] flex sm:items-center flex-col sm:flex-row gap-[17px]'>
+        <div className='flex flex-col gap-[10px] bg-status w-full sm:w-[230px] h-[130px] sm:h-[230px] rounded-[12px] sm:rounded-[20px] py-4 px-4 relative'>
           <span className='text-[15px] font-semibold text-white'>
-            {role} Status
+            <span className='hidden sm:block'>{role}</span> Status
           </span>
-          <div className='absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] flex flex-col text-center'>
-            <span className='text-[50px]'>
+          <div className='absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] flex flex-row sm:flex-col text-center gap-3 sm:gap-0'>
+            <span className='text-[18px] sm:text-[50px]'>
               {STATUS_EMOJI.find((el) =>
                 el.label.startsWith(profileInfo?.status as string)
-              )?.label.slice(-2)}
+              )?.label.slice(-2) || '👀'}
             </span>
-            <span className='text-white'>{profileInfo?.status}</span>
+            <span className='text-white'>
+              {profileInfo?.status || '프로젝트 탐색 중'}
+            </span>
           </div>
         </div>
         <Contribution

--- a/src/components/templates/MyPage/MyPageTemplate.tsx
+++ b/src/components/templates/MyPage/MyPageTemplate.tsx
@@ -34,21 +34,28 @@ const MyPageTemplate = () => {
   }, [resetApplyForm]);
 
   return (
-    <div className='w-full min-h-screen max-w-[1920px] bg-background'>
+    <div className='w-full min-h-screen max-w-[1920px] bg-background lg:px-0 px-4'>
       <div className='max-w-screen-center h-full mx-auto flex flex-col gap-[17px]'>
         <MyPageHeader />
         <div className='h-[38px]'>
           <Tabs>
-            {Object.keys(MyPageTabs).map((tab, index) => (
-              <Tabs.TabItem
-                key={tab}
-                hideDivider={index == 3}
-                onClick={() => setActiveTab(tab)}
-                isActive={activeTab === tab}
-              >
-                {tab}
-              </Tabs.TabItem>
-            ))}
+            {Object.keys(MyPageTabs).map((tab, index) => {
+              console.log(window.innerWidth);
+              const displayTab =
+                tab === '커넥션 허브' && window.innerWidth <= 410
+                  ? '허브'
+                  : tab;
+              return (
+                <Tabs.TabItem
+                  key={tab}
+                  hideDivider={index == 3}
+                  onClick={() => setActiveTab(tab)}
+                  isActive={activeTab === tab}
+                >
+                  {displayTab}
+                </Tabs.TabItem>
+              );
+            })}
           </Tabs>
         </div>
         {ActiveComponent ? <ActiveComponent /> : null}

--- a/src/components/templates/SettingsTemplate.tsx
+++ b/src/components/templates/SettingsTemplate.tsx
@@ -2,7 +2,6 @@ import AccountSection from '@/components/organisms/settings/AccountSection';
 import InfoSection from '@/components/organisms/settings/InfoSection';
 import NotificationSection from '@/components/organisms/settings/NotificationSection';
 import { useGetSettingsInfo } from '@/hooks/queries/mypage/settings';
-import { ArrowUpIcon } from '@heroicons/react/24/outline';
 import { useRef } from 'react';
 
 const SettingsTemplate = () => {
@@ -10,23 +9,11 @@ const SettingsTemplate = () => {
 
   const { data: settingsInfo } = useGetSettingsInfo();
 
-  const handleScrollToTop = () => {
-    if (viewRef.current) {
-      viewRef.current.scrollIntoView({ behavior: 'smooth' });
-    }
-  };
-
   return (
     <div
       className='relative w-full h-full mx-auto px-[30px] mt-[-24px] pt-6'
       ref={viewRef}
     >
-      <button
-        className='fixed bottom-[50px] right-[200px] w-10 h-10 bg-white rounded-full shadow-lg flex justify-center items-center'
-        onClick={handleScrollToTop}
-      >
-        <ArrowUpIcon width={24} />
-      </button>
       <div className='flex flex-col gap-[100px]'>
         <InfoSection settingsInfo={settingsInfo!} />
         <NotificationSection settingsInfo={settingsInfo!} />

--- a/src/layouts/HubLayout.tsx
+++ b/src/layouts/HubLayout.tsx
@@ -9,7 +9,7 @@ const HubLayout = () => {
 
   return (
     <div className='min-h-screen flex flex-col lg:flex-row lg:px-[10px]'>
-      <div className='sticky top-0 w-full lg:w-[68px] h-[52px] lg:h-screen lg:px-4 flex items-center justify-between bg-white z-50'>
+      <div className='sticky top-0 w-full lg:w-[68px] h-[52px] lg:h-screen lg:px-4 flex items-center justify-between z-50'>
         <div className='hidden lg:block w-full h-full'>
           <SideMenu />
         </div>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -19,7 +19,7 @@ const MainLayout = () => {
 
   return (
     <div className='min-h-screen flex flex-col lg:flex-row lg:px-[10px]'>
-      <div className='sticky top-0 w-full lg:w-[68px] h-[52px] lg:h-screen lg:px-4 flex items-center justify-between bg-white z-50'>
+      <div className='sticky top-0 w-full lg:w-[68px] h-[52px] lg:h-screen lg:px-4 flex items-center justify-between z-50'>
         <div className='hidden lg:block w-full h-full'>
           <SideMenu />
         </div>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -12,7 +12,10 @@ const MainLayout = () => {
   const { isModalOpen, openModal, closeModal } = useSearchModal();
 
   useEffect(() => {
-    if (window.location.href.includes('q=')) {
+    if (
+      window.location.href.includes('q=') &&
+      !window.location.href.includes('type=page')
+    ) {
       openModal();
     }
   }, [location]);

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -2,10 +2,20 @@ import { Outlet, useLocation } from 'react-router-dom';
 import SideMenu from '@/components/organisms/sides/SideMenu';
 import MainSideBar from '@/components/organisms/sides/MainSideBar';
 import MobileNav from '@/components/organisms/sides/MobileNav';
+import { useEffect } from 'react';
+import { useSearchModal } from '@/store/modals/searchModalstore';
+import SearchModal from '@/components/organisms/modals/SearchModal';
 
 const MainLayout = () => {
   const preventInfo = ['/login'];
   const location = useLocation();
+  const { isModalOpen, openModal, closeModal } = useSearchModal();
+
+  useEffect(() => {
+    if (window.location.href.includes('q=')) {
+      openModal();
+    }
+  }, [location]);
 
   return (
     <div className='min-h-screen flex flex-col lg:flex-row lg:px-[10px]'>
@@ -19,6 +29,7 @@ const MainLayout = () => {
       </div>
       <div className='flex-1 overflow-y-auto'>
         <div className='max-w-[800px] w-full mx-auto py-6'>
+          {isModalOpen && <SearchModal onClose={closeModal} />}
           <Outlet />
         </div>
       </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #147 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 마이페이지에 적응형 적용
- 계정 설정 페이지에 적응형 적용
- 검색 페이지에 적응형 적용
- 이전에 에러로 주석처리해두었던 검색 모달 관련 로직을 다시 수정했습니다.
  - 검색 모달로 검색 -> 검색 결과 페이지(허브/피드) 또는 검색 페이지로 이동 - 이전 페이지로 이동 클릭 시 -> 검색 모달 & 검색어 다시 표시
  - (모바일) 검색 바로 검색 -> 검색 페이지로 이동 -> 이전 페이지로 이동 클릭 시 -> 이전 페이지로 이동
- **모바일 네비게이션에서 로고 크기, 인풋 디자인(검색모달 차용)을 변경**했으니 시간 되실 때 확인 부탁드립니다.


### 스크린샷 (선택)
<img width="400" alt="스크린샷 2025-03-09 오전 11 42 31" src="https://github.com/user-attachments/assets/17e87a1e-5fd5-4d00-bd80-99f054782b59" />
<img width="380" alt="스크린샷 2025-03-09 오전 11 42 39" src="https://github.com/user-attachments/assets/b1923e8a-4357-466d-9df3-cfa6596496e8" />
<img width="240" alt="스크린샷 2025-03-09 오전 11 42 42" src="https://github.com/user-attachments/assets/c0c483de-7a1e-4880-a59a-bf7c362800aa" />

<img width="240" alt="스크린샷 2025-03-09 오전 11 43 08" src="https://github.com/user-attachments/assets/69a5697e-a455-4845-bf7c-4841c56e63b8" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?